### PR TITLE
crash fix

### DIFF
--- a/SODEQItemConverters.h
+++ b/SODEQItemConverters.h
@@ -59,7 +59,7 @@ protected:
 
 		while (*ptr)
 		{
-			char szField[256];
+			char szField[1024];
 			char* pDest = szField;
 			bool bEscape = false;
 


### PR DESCRIPTION
making the field buffer larger - should refactor this to not use staticly sized arrays later