### PR TITLE
fix openssl dep

### DIFF
--- a/MQ2LinkDB.vcxproj
+++ b/MQ2LinkDB.vcxproj
@@ -24,10 +24,10 @@
       <Message>Updating version resource for $(MSBuildProjectName)...</Message>
     </PreBuildEvent>
     <Link>
-      <AdditionalDependencies Condition="'$(Configuration)'=='Release'">sqlite3.lib;cpr.lib;libcurl.lib;zlib.lib;Ws2_32.lib;libcrypto.lib;libssl.lib;crypt32.lib</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Configuration)'=='Release'">sqlite3.lib;cpr.lib;libcurl-84.lib;zlib.lib;Ws2_32.lib;crypt32.lib</AdditionalDependencies>
     </Link>
     <Link>
-      <AdditionalDependencies Condition="'$(Configuration)'=='Debug'">sqlite3.lib;cpr.lib;libcurl-d.lib;zlibd.lib;Ws2_32.lib;libcrypto.lib;libssl.lib;crypt32.lib</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Configuration)'=='Debug'">sqlite3.lib;cpr.lib;libcurl-84-d.lib;zlibd.lib;Ws2_32.lib;crypt32.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <PropertyGroup Label="Globals">

--- a/vcpkg_mq.txt
+++ b/vcpkg_mq.txt
@@ -1,4 +1,4 @@
-curl[schannel]
+curl-84[schannel]
 cpr
 pe-parse
 sqlite3

--- a/vcpkg_mq.txt
+++ b/vcpkg_mq.txt
@@ -1,4 +1,3 @@
 curl-84[schannel]
 cpr
-pe-parse
 sqlite3


### PR DESCRIPTION
project failed to build without openssl

@Knightly1 confirmed this was a dependency configuration issue

openssl dep removed, but update was failing:

![image](https://github.com/user-attachments/assets/642bc283-fd94-435b-9fe6-68503c6cac31)

after changing libcurl to 8.4:

![image](https://github.com/user-attachments/assets/45c0fe40-4cfe-477f-943f-24ebc5cbd06c)

also removed `pe-parse` per discord discussion

ref:

- https://discord.com/channels/511690098136580097/516740615015235586/1306760669399613531